### PR TITLE
chore: fix release workflow triggers

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Bump Cargo.toml version
         id: bump
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           files: release/*
           overwrite_files: true
+          generate_release_notes: true
           token: ${{ secrets.RELEASE_TOKEN || github.token }}
 
   update-homebrew-tap:


### PR DESCRIPTION
## Summary
- enable autogenerated release notes in release workflow
- use RELEASE_TOKEN checkout so tag pushes from bump workflow trigger releases

## Testing
- not run (workflow changes only)