### PR TITLE
Fix TUI lockups under log floods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "piperack"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,9 @@ cargo llvm-cov
 - Verify shutdown UX:
   - `q` shows persistent "shutting down" status and exits cleanly.
   - `k` shows "sent SIGINT" immediately for a process.
+- Verify high-volume output doesn't freeze the UI:
+  - `cargo run -- -- --name spam -- sh -c "yes | head -n 100000"`
+  - UI stays responsive; you can still select and kill the process.
 - Verify clipboard selection:
   - Mouse drag selects log lines.
   - Ctrl+C copies selection; if none, copies full selected process buffer.


### PR DESCRIPTION
## Summary
- Split output events into a dedicated channel so input/shutdown stays responsive under heavy logs.
- Throttle TUI redraws to ~30fps and drop excess output with a summary line in TUI mode.
- Document a manual smoke test for high-volume output.

## Testing
- manual: `cargo run -- -- --name spam -- sh -c "yes"`

Fixes #9.
